### PR TITLE
Support for headingText and headingTag options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+/.idea

--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@ Generated TOC:
 
 ```javascript
 const defaults = {
-  tags: ['h2', 'h3', 'h4'], // which heading tags are selected (headings must each have an ID attribute)
-  wrapper: 'nav',           // element to put around the root `ol`
-  wrapperClass: 'toc'       // class for the element around the root `ol`
+  tags: ['h2', 'h3', 'h4'], // Which heading tags are selected (headings must each have an ID attribute)
+  wrapper: 'nav',       // Element to put around the root `ol`
+  wrapperClass: 'toc',  // Class for the element around the root `ol`
+  headingText: '',      // Optional text to show in heading above the wrapper element
+  headingTag: 'h2'      // Heading tag when showing heading above the wrapper element
 }
 ```
 
@@ -66,7 +68,7 @@ npm i --save eleventy-plugin-nesting-toc
 
 ### Adding it to the Eleventy Engine
 
-Note: Your heading tags will need to have `id`s on them, so that the TOC can provide proper anchor links to them. Eleventy does not do this for you ootb. You can use a plugin like [markdown-it-anchor](https://www.npmjs.com/package/markdown-it-anchor) to add those `id`s to the headings automagically
+**IMPORTANT NOTE**: Your heading tags will need to have `id`s on them, so that the TOC can provide proper anchor links to them. Eleventy does not do this for you ootb. You can use a plugin like [markdown-it-anchor](https://www.npmjs.com/package/markdown-it-anchor) to add those `id`s to the headings automagically
 
 ```diff
 // .eleventy.js
@@ -94,7 +96,7 @@ module.exports = function (eleventyConfig) {
 ```nunjucks
 <aside>
   {{ content | toc | safe }}
-</article>
+</aside>
 <article>
   {{ content }}
 </article>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eleventy-plugin-nesting-toc",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Eleventy plugin which adds a filter to generate a Table of Contents from html",
   "main": ".eleventy.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -32,6 +32,24 @@ const tests = {
         assert.equal(results.children[1].text, 'Baz');
     },
 
+    withHeadingTextOptions() {
+        const toc = new Toc(`<h2 id="foo">Foo</h2>`, {headingText: 'Sections'});
+        const html = toc.html();
+        assert.ok(html.includes(`<h2>Sections</h2>`), 'TOC heading of h2 was not found');
+    },
+
+    withHeadingTextAndHeadingTagOptions() {
+        const toc = new Toc(`<h2 id="foo">Foo</h2>`, {headingText: 'Sections', headingTag: 'h5'});
+        const html = toc.html();
+        assert.ok(html.includes(`<h5>Sections</h5>`), 'TOC heading of h5 was not found');
+    },
+
+    withHeadingOptionsButNoHeadings() {
+        const toc = new Toc(`<div>Hello World</div>`, {headingText: 'Sections'});
+        const html = toc.html();
+        assert.ok(!html.includes(`<h2>Sections</h2>`), 'Unexpected TOC heading of h2 was found');
+    },
+
     nesting() {
         const toc = new Toc(`
             <h1>Foo</h1>

--- a/toc.js
+++ b/toc.js
@@ -3,7 +3,9 @@ const cheerio = require('cheerio');
 const defaults = {
     tags: ['h2', 'h3', 'h4'],
     wrapper: 'nav',
-    wrapperClass: 'toc'
+    wrapperClass: 'toc',
+    headingText: '',
+    headingTag: 'h2'
 };
 
 function getParent(prev, current) {
@@ -81,13 +83,21 @@ class Toc {
     }
 
     html() {
-        const {wrapper, wrapperClass} = this.options;
-        return `
-<${wrapper} class="${wrapperClass}">
-    ${this.get().html()}
-</${wrapper}>
-`
+        const {wrapper, wrapperClass, headingText, headingTag} = this.options;
+        const root = this.get();
 
+        let html = '';
+
+        if (root.children.length) {
+
+            if (headingText) {
+                html += `<${headingTag}>${headingText}</${headingTag}>\n`;
+            }
+
+            html += `<${wrapper} class="${wrapperClass}">${root.html()}</${wrapper}>`;
+        }
+
+        return html;
     }
 }
 


### PR DESCRIPTION
A TOC heading can be displayed above the unordered list.
If there are no headings found in the input, TOC heading not output.
README.md tweaks to cover new options.