### PR TITLE
Add ability to filter out certain elements when constructing labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Generated TOC:
 ```javascript
 const defaults = {
   tags: ['h2', 'h3', 'h4'], // Which heading tags are selected (headings must each have an ID attribute)
+  ignoredElements: [],  // Elements to ignore when constructing the label for every header (useful for ignoring permalinks, must be selectors)
   wrapper: 'nav',       // Element to put around the root `ol`
   wrapperClass: 'toc',  // Class for the element around the root `ol`
   headingText: '',      // Optional text to show in heading above the wrapper element

--- a/test.js
+++ b/test.js
@@ -44,6 +44,16 @@ const tests = {
         assert.equal(results.children[0].text, 'Section 1');
     },
 
+    twoH2sWithElementsToIgnoreInOne() {
+        const toc = new Toc(`
+                <h1>Page Title</h1>
+                    <h2 id="section1">Section 1</h2>
+                    <h2 id="section2">Section 2 <a class="permalink">#</a></h2>
+        `, {ignoredElements: ['.permalink']})
+        const results = toc.get();
+        assert.equal(results.children[1].text, 'Section 2')
+    },
+
     withHeadingTextOptions() {
         const toc = new Toc(`<h2 id="foo">Foo</h2>`, {headingText: 'Sections'});
         const html = toc.html();

--- a/toc.js
+++ b/toc.js
@@ -5,6 +5,7 @@ const ignoreAttribute = 'data-toc-exclude';
 
 const defaults = {
     tags: ['h2', 'h3', 'h4'],
+    ignoredElements: [],
     wrapper: 'nav',
     wrapperClass: 'toc',
     headingText: '',
@@ -28,7 +29,7 @@ class Item {
     constructor($el) {
         if ($el) {
             this.slug = $el.attr('id');
-            this.text = $el.text();
+            this.text = $el.text().trim();
             this.level = +$el.get(0).tagName.slice(1);
         } else {
             this.level = 0;
@@ -71,6 +72,9 @@ class Toc {
         const headings = $(selector)
             .filter('[id]')
             .filter(`:not([${ignoreAttribute}])`);
+
+        const ignoredElementsSelector = this.options.ignoredElements.join(',')
+        headings.find(ignoredElementsSelector).remove()
 
         if (headings.length) {
             let previous = this.root;


### PR DESCRIPTION
This fix #5 by allowing users to add a list of items to filter out when constructing the labels for the toc.

It works like so:

```js
const toc = new Toc(`
        <h1>Page Title</h1>
            <h2 id="section1">Section 1</h2>
            <h2 id="section2">Section 2 <a class="permalink">#</a></h2>
`, {ignoredElements: ['.permalink']})
```

result in the following html:
```html
<ol>
    <li>
        <a href="#section1">Section 1</a>
    </li>
    <li>
        <a href="#section2">Section 2</a>
    </li>
</ol>
```

Before this PR, it would have resulted in Section 2 being `Section 2 #` instead of Section 2. Tests have been added and the README has been edited.